### PR TITLE
Fix game creating issue

### DIFF
--- a/src/UltraMafia/GameService.cs
+++ b/src/UltraMafia/GameService.cs
@@ -169,7 +169,7 @@ namespace UltraMafia
                     {
                         RoomId = creationInfo.roomId,
                         State = GameSessionStates.Registration,
-                        CreatedByGamerAccountId = creationInfo.roomId
+                        CreatedByGamerAccountId = creationInfo.gamerId
                     };
                     await dbContextAccessor.DbContext.AddAsync(createdSession);
                     await dbContextAccessor.DbContext.SaveChangesAsync();
@@ -232,6 +232,8 @@ namespace UltraMafia
 
                     await dbContextAccessor.DbContext.Entry(currentSession).Collection(s => s.GameMembers).Query()
                         .Include(gm => gm.GamerAccount).LoadAsync();
+                    await dbContextAccessor.DbContext.Entry(currentSession).Reference(s => s.CreatedByGamerAccount)
+                        .LoadAsync();
                 }
 
                 _frontend.OnGamerJoined(currentSession, joinedGamerAccount);


### PR DESCRIPTION
Fixes this issue:
```
mafia_mafia-game.1.gqg644859o6w@docker    | System.NullReferenceException: Object reference not
 set to an instance of an object.
mafia_mafia-game.1.gqg644859o6w@docker    |    at UltraMafia.Frontend.Telegram.TelegramFrontend
Extensions.CreateOrUpdateRegistrationMessage(ITelegramBotClient bot, GameSession session, Teleg
ramFrontendSettings settings) in /tmp/src/UltraMafia/Frontend/Telegram/TelegramFrontendExtensio
ns.cs:line 109
mafia_mafia-game.1.gqg644859o6w@docker    |    at UltraMafia.Frontend.Telegram.TelegramFrontend
.<>c__DisplayClass33_0.<<OnGamerJoined>b__0>d.MoveNext() in /tmp/src/UltraMafia/Frontend/Telegr
am/TelegramFrontend.cs:line 562
mafia_mafia-game.1.gqg644859o6w@docker    | --- End of stack trace from previous location where
 exception was thrown ---
mafia_mafia-game.1.gqg644859o6w@docker    |    at UltraMafia.Frontend.Telegram.TelegramFrontend
Extensions.LockAndDo(ITelegramBotClient bot, Func`1 action) in /tmp/src/UltraMafia/Frontend/Tel
egram/TelegramFrontendExtensions.cs:line 171
```